### PR TITLE
Stylehacks

### DIFF
--- a/Resources/Public/JavaScript/Module/Application.js
+++ b/Resources/Public/JavaScript/Module/Application.js
@@ -37,6 +37,9 @@ Ext.ux.TYPO3.Newsletter.Module.Application = Ext.apply(new Ext.util.Observable()
         if (this.checkIfPage()) {
             this.initStore();
             this.initGui();
+            /* Insert typo3-docheaders to get a consistent backend-module-look */
+            Ext.get('main-tabs').insertHtml('beforeBegin','<div class="typo3-docheader-functions"></div>');
+            Ext.get('main-tabs').insertHtml('beforeBegin','<div class="typo3-docheader-buttons"></div>');
         } else if (this.checkIfPageIsFolder()) {
             this.initFolderGui();
         } else {
@@ -71,6 +74,10 @@ Ext.ux.TYPO3.Newsletter.Module.Application = Ext.apply(new Ext.util.Observable()
                     id: 'main-tabs',
                     xtype: 'tabpanel',
                     activeTab: 0,
+                    border: false,
+                    headerCssClass: 't3-newsletter-docheader',
+                    bodyCssClass: 't3-newsletter-docbody',
+                    padding: '0 20px 10px 24px',
                     items: [{
                             xtype: 'Ext.ux.TYPO3.Newsletter.Planner.Planner',
                             iconCls: 't3-newsletter-button-planner',

--- a/Resources/Public/JavaScript/Planner/Planner.js
+++ b/Resources/Public/JavaScript/Planner/Planner.js
@@ -57,6 +57,8 @@ Ext.ux.TYPO3.Newsletter.Planner.Planner = Ext.extend(Ext.form.FormPanel, {
                 {
                     xtype: 'tabpanel',
                     activeTab: 0,
+                    padding: '10px',
+                    border: false,
                     items: [
                         {
                             height: 500,

--- a/Resources/Public/Styles/module.css
+++ b/Resources/Public/Styles/module.css
@@ -102,3 +102,55 @@ ul.infos li.none {
 {
     height: 100%;
 }
+
+.typo3-docheader-functions {
+    position: absolute;
+    width: 100%;
+}
+.typo3-docheader-buttons {
+    position: absolute;
+    width: 100%;
+    top: 27px;
+}
+
+/* ExtJS mods */
+.t3-newsletter-docbody {
+    background: transparent;
+}
+/* Correct space between tabs to match TYPO3-look (should be solved in global ExtJS-theme!) */
+ul.x-tab-strip li {
+    margin-right: 1px;
+}
+/* Set border around panels and newsletterListMenu */
+#newsletterListMenu .x-panel-body,
+.t3-newsletter-docbody .x-tab-panel-body {
+    border: 1px solid #adadad;
+    border-top-width: 0;
+}
+/* Remove padding around tab-text to make it look like TYPO3 */
+/* Set fixed height for 6.1 */
+.x-tab-strip span.x-tab-strip-text,
+.x-tab-strip-top .x-tab-strip-active .x-tab-right span.x-tab-strip-text {
+    padding: 0;
+    height: 18px;
+}
+/* Set different margins for tabpanels */
+.t3-newsletter-docheader ul.x-tab-strip-top {
+    margin: 17px 24px;
+}
+.t3-newsletter-docbody ul.x-tab-strip-top {
+    margin-bottom: 0;
+    margin-top: 0;
+}
+/* Correct background-color in border-layout */
+.x-border-layout-ct {
+    background-color: transparent;
+}
+/* Correct background-color for pagination in RecipientList */
+.x-toolbar {
+    background: none;
+}
+/* Correct background-color of tabpanels */
+.x-tab-panel-header {
+    background: none;
+}


### PR DESCRIPTION
Modified some parts in JS to imitate the styling of a TYPO3-backend-module in v6.2.
Tested with version 6.2 and 6.1.7 with two different backend-skins but only in chrome under Linux.
![screenshot-newsletter](https://cloud.githubusercontent.com/assets/2480602/4337748/6765fb36-4012-11e4-96fd-83559fb89e0b.png)
