### PR TITLE
Issue Updating: Refactorisation of extension updating

### DIFF
--- a/Classes/AbstractUpdate.php
+++ b/Classes/AbstractUpdate.php
@@ -1,0 +1,551 @@
+<?php
+namespace Ecodev\Newsletter;
+
+use Ecodev\Newsletter\Update\Task;
+use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Backend\Utility\IconUtility;
+use TYPO3\CMS\Core\Messaging\FlashMessage;
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
+
+/*
+ * *************************************************************
+ * Copyright notice
+ *
+ * (c) 2015
+ * All rights reserved
+ *
+ * This script is part of the TYPO3 project. The TYPO3 project is
+ * free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * The GNU General Public License can be found at
+ * http://www.gnu.org/copyleft/gpl.html.
+ *
+ * This script is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * This copyright notice MUST APPEAR in all copies of the script!
+ * *************************************************************
+ */
+require_once PATH_typo3 . 'sysext/core/Classes/SingletonInterface.php';
+
+/**
+ * Update for newsletter extension
+ *
+ * @license http://www.gnu.org/licenses/gpl.html GNU General Public License, version 3 or later
+ * @author marvin-martian https://github.com/marvin-martian
+ */
+abstract class AbstractUpdate implements \TYPO3\CMS\Core\SingletonInterface
+{
+
+    protected static $EXTKEY = 'newsletter';
+
+    /**
+     * Current extension version.
+     *
+     * @var $version string
+     */
+    protected static $version;
+
+    /**
+     * Extension Manager configuration of the extension
+     *
+     * @var $configManager \TYPO3\CMS\Core\Configuration\ConfigurationManager
+     */
+    protected static $configManager;
+
+    /**
+     * The local config of extension.
+     *
+     * @var $localConfig array
+     */
+    protected static $localConfig;
+
+    /**
+     * An array of updates to perform.
+     *
+     * @var $updates array
+     */
+    protected static $updateRegister;
+
+    /**
+     * An array of previous update tasks called.
+     *
+     * @var $updateHistory array
+     */
+    protected static $updateHistory;
+
+    /**
+     * Extension Manager configuration of the extension
+     *
+     * @var $updateHistory array
+     */
+    protected static $updateResults;
+
+    // Public Methods
+    // ////////////////////////////////////////////////////////////////////////////////////////////////////
+
+    /**
+     * Class constructor
+     *
+     * @param string $extkey
+     */
+    public function _construct($extkey = 'newsletter')
+    {
+        self::init($extkey);
+    }
+
+    /**
+     * This is the public execution method that is triggered for manual updates.
+     *
+     * @return string HTML Content for manual updated.
+     */
+    public static function main()
+    {
+        $html = '';
+        // Just a sanity check to make sure the extension is loaded.
+        if (! ExtensionManagementUtility::isLoaded(self::$EXTKEY)) {
+            return $html;
+        }
+        // Init the statics if necessary
+        self::init(self::$EXTKEY);
+        // If we have tasks to process.
+        if (! empty(self::$updateRegister[Task::MANUAL_UPDATE])) {
+            // Check on Form Submission.
+            $formVars = GeneralUtility::_POST('tx_' . self::$EXTKEY);
+            $message = '';
+            $results = '';
+            if ($formVars && ! empty($formVars['update'])) {
+                if (! empty($formVars['update-tasks'])) {
+                    // Set the seleceted tasks
+                    $updateTasks = array_values($formVars['update-tasks']);
+                    // Set the executable state of selected tasks.
+                    /* @var $task \Ecodev\Newsletter\Update\Task */
+                    foreach (self::$updateRegister[Task::MANUAL_UPDATE] as &$task) {
+                        $task->canExecute(in_array($task->getTaskId(), $updateTasks));
+                    }
+                    // Start the manual updates.
+                    self::doUpdates(Task::MANUAL_UPDATE);
+                    // Set display HTML results;
+                    if (! empty($formVars['update-tasks'])) {
+                        $successState = '';
+                        // Table header
+                        $resultsTable = '<br /><table class="t3-table">';
+                        $resultsTable .= '<thead>';
+                        $resultsTable .= '<tr role="row">';
+                        $resultsTable .= '<th></th>';
+                        $resultsTable .= '<th>' . self::__('ext-update.task') . '</th>';
+                        $resultsTable .= '<th>' . self::__('ext-update.since') . '</th>';
+                        $resultsTable .= '<th style="white-space: nowrap;">' . self::__('ext-update.records_modified') . '</th>';
+                        $resultsTable .= '<th style="white-space: nowrap;">' . self::__('ext-update.files_modified') . '</th>';
+                        $resultsTable .= '<th>' . self::__('ext-update.problems') . '</th>';
+                        $resultsTable .= '</tr>';
+                        $resultsTable .= '</thead>';
+                        $resultsTable .= '<tbody>';
+                        // Step through results
+                        foreach (self::$updateResults as &$task) {
+                            // Set the success state.
+                            if ($task->getExecResult()->success) {
+                                $successState = $successState == '' ? FlashMessage::OK : $successState;
+                            } else {
+                                // Check if the failure was destructive or not.
+                                if ($task->getExecResult()->recordsCommitted || $task->getExecResult()->filesCommitted) {
+                                    $successState = $successState != FlashMessage::ERROR ? FlashMessage::ERROR : $successState;
+                                } else {
+                                    $successState = $successState != FlashMessage::ERROR ? FlashMessage::WARNING : $successState;
+                                }
+                            }
+                            $taskIcon = $task->getExecResult()->success ? 'status-dialog-ok' : (($task->getExecResult()->recordsCommitted || $task->getExecResult()->filesCommitted) ? 'status-dialog-error' : 'status-dialog-warning');
+                            $taskProblems = empty($task->getExecResult()->errorMessage) ? '<i>' . self::__('ext-update.none') . '</i>' : self::__(htmlspecialchars($task->getExecResult()->errorMessage));
+                            // Render row.
+                            $resultsTable .= '<tr role="row">';
+                            $resultsTable .= '<td>' . IconUtility::getSpriteIcon($taskIcon) . '</td>';
+                            $resultsTable .= '<td>' . self::__($task->getDescription()) . '</td>';
+                            $resultsTable .= '<td>' . 'v' . $task->getUpdateVersion() . '</td>';
+                            $resultsTable .= '<td style="text-align:center;">' . $task->getExecResult()->numRecordsModified . '</td>';
+                            $resultsTable .= '<td style="text-align:center;">' . $task->getExecResult()->numFilesModified . '</td>';
+                            $resultsTable .= '<td>' . $taskProblems . '</td>';
+                            $resultsTable .= '</tr>';
+                        }
+                        $resultsTable .= '</tbody></table>';
+                        // Set the success state messages.
+                        $successStateMessage = '';
+                        $successStateMessageHeader = '';
+                        switch ($successState) {
+                            case FlashMessage::OK:
+                                $successStateMessage = self::__('ext-update.all_updates_completed_successfully');
+                                $successStateMessageHeader = self::__('ext-update.update_success');
+                                break;
+                            case FlashMessage::WARNING:
+                                $successStateMessage = self::__('ext-update.some_update_problems_but_data_integrity_kept') . ' ' . self::__('ext-update.please_review_update_results_below');
+                                $successStateMessageHeader = self::__('ext-update.update_warning');
+                                break;
+                            case FlashMessage::ERROR:
+                                $successStateMessage = self::__('ext-update.some_critical_update_problems') . ' ' . self::__('ext-update.please_review_update_results_below');
+                                $successStateMessageHeader = self::__('ext-update.update_error');
+                                break;
+                        }
+                        if ($successState !== '') {
+                            // Set the Success State if we have one.
+                            /* @var $flashMessage \TYPO3\CMS\Core\Messaging\FlashMessage */
+                            $flashMessage = GeneralUtility::makeInstance('TYPO3\\CMS\\Core\\Messaging\\FlashMessage', $successStateMessage, $successStateMessageHeader, $successState);
+                            $message .= $flashMessage->render();
+                        }
+
+                        // Set the Update Results
+                        /* @var $flashMessage \TYPO3\CMS\Core\Messaging\FlashMessage */
+                        $flashMessage = GeneralUtility::makeInstance('TYPO3\\CMS\\Core\\Messaging\\FlashMessage', $resultsTable, self::__('ext-update.update_results'), \TYPO3\CMS\Core\Messaging\FlashMessage::NOTICE);
+                        $message .= $flashMessage->render();
+                    }
+                } else {
+                    /* @var $flashMessage \TYPO3\CMS\Core\Messaging\FlashMessage */
+                    $flashMessage = GeneralUtility::makeInstance('TYPO3\\CMS\\Core\\Messaging\\FlashMessage', self::__('ext-update.no_tasks_selected'), self::__('ext-update.attention'), \TYPO3\CMS\Core\Messaging\FlashMessage::WARNING);
+                    $message .= $flashMessage->render();
+                }
+            }
+            // Init the statics again, if the form was submitted the local config may have changed.
+            self::init(self::$EXTKEY);
+            // Create Form ID
+            $idAttrValue = uniqid(self::$EXTKEY);
+            // Some Inline JS for row clicking checkbox toggle
+            $script = '';
+            $script .= '<script type="text/javascript">';
+            $script .= '/*<![CDATA[*/ ';
+            $script .= 'jQuery.noConflict();';
+            $script .= 'jQuery( document ).ready(function() {';
+            $script .= 'jQuery(\'#' . $idAttrValue . ' table tbody tr\').filter(\':has(:checkbox:checked)\').addClass(\'selected\').end().click(function(event) {';
+            $script .= 'jQuery(this).toggleClass(\'selected\');if (event.target.type !== \'checkbox\') {';
+            $script .= 'jQuery(\':checkbox\', this).each(function() {jQuery(this).prop(\'checked\',!this.checked); });';
+            $script .= '}';
+            $script .= '});';
+            $script .= '});';
+            $script .= ' /*]]>*/';
+            $script .= '</script>';
+            // Build the update form
+            $form = '';
+            $form .= '<form id="' . $idAttrValue . '" name="tx_' . self::$EXTKEY . '[updateForm]" action ="" method="post">';
+            $form .= '<fieldset>';
+            $form .= '<legend><h4>&nbsp;' . self::__('ext-update.manual_updates') . '&nbsp;</h4></legend>';
+            $form .= '<p>' . self::__('ext-update.select_manual_tasks') . '<br />' . self::__('ext-update.new_install_advice') . '</p>';
+            $form .= '<p>' . self::__('ext-update.current_version', array(
+                '<u>v' . self::$version . '</u>',
+            )) . '</p>';
+            $form .= '<h4>' . self::__('ext-update.update_tasks') . '</h4>';
+            $form .= '<table class="t3-table">';
+            $form .= '<thead>';
+            $form .= '<tr role="row">';
+            $form .= '<th></th>';
+            $form .= '<th>' . self::__('ext-update.task') . '</th>';
+            $form .= '<th>' . self::__('ext-update.since') . '</th>';
+            $form .= '<th>' . self::__('ext-update.update_type') . '</th>';
+            $form .= '<th>' . self::__('ext-update.last_updated') . '</th>';
+            $form .= '</tr>';
+            $form .= '</thead>';
+            $form .= '<tbody>';
+            /* @var $task \Ecodev\Newsletter\Update\Task */
+            foreach (self::$updateRegister[Task::MANUAL_UPDATE] as &$task) {
+                // set some attributes
+                $idAttrValue = uniqid(self::$EXTKEY);
+                $checked = $task->isUpdated() ? '' : ' checked="checked"';
+                // set some pretty dates.
+                $age = $task->getLastUpdate() > - 1 ? (time() - $task->getLastUpdate()) : - 1;
+                $lastUpdate = $task->getLastUpdate() > - 1 ? ($age < (3600 * 3) ? self::__('ext-update.ago', array(
+                    BackendUtility::calcAge($age, $GLOBALS["LANG"]->sL("LLL:EXT:lang/locallang_core.xlf:labels.minutesHoursDaysYears")),
+                )) : strftime('%c', $task->getLastUpdate())) : '<i>' . self::__('ext-update.never') . '</i>';
+                // render row
+                $form .= '<tr role="row" >';
+                $form .= '<td><input type="checkbox" id="' . $idAttrValue . '" name="tx_' . self::$EXTKEY . '[update-tasks][' . $task->getTaskId() . ']" value="' . $task->getTaskId() . '"' . $checked . '></td>';
+                $form .= '<td>' . self::__($task->getDescription()) . '</td>';
+                $form .= '<td>' . 'v' . $task->getUpdateVersion() . '</td>';
+                $form .= '<td>' . $task->getTaskType() . '</td>';
+                $form .= '<td>' . $lastUpdate . '</td>';
+                $form .= '</tr>';
+            }
+            $form .= '</tbody>';
+            $form .= '</table>';
+            $idAttrValue = uniqid(self::$EXTKEY);
+            $form .= '<br /><input id="' . $idAttrValue . '" type="submit" name="tx_' . self::$EXTKEY . '[update]" value="' . self::__('ext-update.update_selected') . '" />';
+            $form .= '</fieldset>';
+            $form .= '</form>';
+            // put it all together.
+            $html = $message . ' <br />' . $form . $script;
+        }
+
+        return $html;
+    }
+
+    /**
+     * This method checks whether it is necessary to display the UPDATE option at all for manual updates.
+     *
+     * @return boolean if user have access, otherwise false
+     */
+    public static function access()
+    {
+        // No point in offering manual updates if the extension is not installed.
+        if (! ExtensionManagementUtility::isLoaded(self::$EXTKEY)) {
+            return false;
+        }
+        // Init the statics if necessary
+        self::init(self::$EXTKEY);
+        // Check if we have any manual tasks to execute.
+        return ! empty(self::$updateRegister[Task::MANUAL_UPDATE]);
+    }
+
+    /**
+     * This is the public execution method that is triggered by the signal/slot for automatic updates.
+     *
+     * @param string $extname
+     */
+    public static function autorun($extname = null)
+    {
+        // Only concerned on running auto-updates if it is the newsletter extension that was installed and IS installed.
+        if ($extname != self::$EXTKEY && ! ExtensionManagementUtility::isLoaded(self::$EXTKEY)) {
+            return;
+        }
+        // Init the statics if necessary
+        self::init(self::$EXTKEY);
+        // Start the auto updates.
+        self::doUpdates(Task::AUTO_UPDATE);
+    }
+
+    /**
+     * Register update tasks.
+     */
+    public static function registerUpdateTasks()
+    {
+    }
+
+    /**
+     * Registers an update task to perform.
+     *
+     * @param \Ecodev\Newsletter\Update\Task $task
+     * @return boolean
+     */
+    public static function registerUpdateTask($task)
+    {
+        if (! ($task instanceof \Ecodev\Newsletter\Update\Task)) {
+            return false;
+        }
+        // Init the statics if necessary
+        self::init(self::$EXTKEY);
+        // Set update status of task.
+        $task->setStatus(self::$updateHistory);
+        switch ($task->getUpdateMode()) {
+            case Task::AUTO_UPDATE:
+            case Task::MANUAL_UPDATE:
+                self::setUpdateRegister($task->getUpdateMode(), $task);
+                break;
+            default:
+                // add them to both lists.
+                self::setUpdateRegister(Task::AUTO_UPDATE, $task);
+                self::setUpdateRegister(Task::MANUAL_UPDATE, $task);
+        }
+
+        return true;
+    }
+
+    // Protected Methods
+    // ////////////////////////////////////////////////////////////////////////////////////////////////////
+
+    /**
+     * Initialize some variables.
+     */
+    protected static function init($extkey)
+    {
+        // Init the static vars if need be.
+        self::$EXTKEY = $extkey;
+        // Get the current extension version.
+        if (! isset(self::$version)) {
+            self::$version = ExtensionManagementUtility::getExtensionVersion(self::$EXTKEY);
+        }
+        // Get a configuration manager
+        if (! isset(self::$configManager) || ! (self::$configManager instanceof TYPO3\CMS\Core\Configuration\ConfigurationManager)) {
+            self::$configManager = GeneralUtility::makeInstance('TYPO3\CMS\Core\Configuration\ConfigurationManager');
+        }
+        // Get/Update local configuration for extension.
+        self::$localConfig = unserialize(self::$configManager->getLocalConfigurationValueByPath('EXT/extConf/' . self::$EXTKEY));
+        // Get what updates have already been performed.
+        if (! isset(self::$updateHistory)) {
+            self::$updateHistory = array();
+        }
+        // Set update history
+        if (isset(self::$localConfig['updateHistory'])) {
+            self::$updateHistory = self::$localConfig['updateHistory'];
+        }
+        // Init the update register
+        if (! isset(self::$updateRegister)) {
+            self::$updateRegister = array(
+                Task::AUTO_UPDATE => array(),
+                Task::MANUAL_UPDATE => array(),
+            );
+            // Register the update tasks.
+            static::registerUpdateTasks();
+        }
+    }
+
+    /**
+     * Update the local configuration
+     */
+    protected static function updateLocalConfig()
+    {
+        // Update the localConfig
+        self::$localConfig['updateHistory'] = self::$updateHistory;
+        $localConfig = array(
+            'EXT' => array(
+                'extConf' => array(
+                    self::$EXTKEY => serialize(self::$localConfig),
+                ),
+            ),
+        );
+        // Write the changes to file.
+        self::$configManager->updateLocalConfiguration($localConfig);
+    }
+
+    /**
+     * Starts a number of update tasks to perform.
+     */
+    protected static function doUpdates($updateMode)
+    {
+        self::$updateResults = array();
+        if (isset(self::$updateRegister) && self::$updateRegister[$updateMode]) {
+            // Execute the tasks.
+            /* @var $task \Ecodev\Newsletter\Update\Task */
+            foreach (self::$updateRegister[$updateMode] as &$task) {
+                if (($task instanceof Task)) {
+                    $task->setCurrentUpdateMode($updateMode);
+                    if ($task->canExecute() && $task->execTask()) {
+                        self::$updateResults[] = $task;
+                    }
+                }
+            }
+            // Process the results
+            self::processUpdateResults($updateMode);
+            // Update local config
+            self::updateLocalConfig();
+        }
+    }
+
+    /**
+     * Sets the update registry with a value pair.
+     *
+     * @param string $updateMode
+     * @param \Ecodev\Newsletter\Update\Task $task
+     */
+    protected static function setUpdateRegister($updateMode, $task)
+    {
+        self::$updateRegister[$updateMode][$task->getTaskId()] = $task;
+        // Sort it by task version
+        uasort(self::$updateRegister[$updateMode], function ($a, $b) {
+            /* @var $a \Ecodev\Newsletter\Update\Task */
+            /* @var $b \Ecodev\Newsletter\Update\Task */
+            return - 1 * version_compare($a->getUpdateVersion(), $b->getUpdateVersion());
+        });
+    }
+
+    /**
+     * Checks and records the state of the update.
+     */
+    protected static function processUpdateResults($updateMode)
+    {
+        if (! empty(self::$updateResults)) {
+            $warnings = array();
+            $successes = array();
+            /* @var $task \Ecodev\Newsletter\Update\Task */
+            foreach (self::$updateResults as &$task) {
+                if ($task->wasExecuted()) {
+                    $execResult = &$task->getExecResult();
+                    if ($execResult->success) {
+                        $successes[] = self::__('"(v%s) %s"', array(
+                            $task->getUpdateVersion(),
+                            $task->getDescription(),
+                        ));
+                        // Add to update history
+                        self::$updateHistory[$task->getTaskId()] = $execResult->executionTime;
+                    } else {
+                        // If for some strange reason it was marked as successful remove it from history.
+                        if (isset(self::$updateHistory[$task->getTaskId()])) {
+                            unset(self::$updateHistory[$task->getTaskId()]);
+                        }
+                        $warnings[] = self::__('"(v%s) %s - Record Integrity: %s - File Integrity: %s - ErrorMessage: %s"', array(
+                            $task->getUpdateVersion(),
+                            $task->getDescription(),
+                            (($execResult->recordsCommitted && $execResult->numRecordsModified > 0) ? 'Modified ' . $execResult->numRecordsModified . ' Records' : 'OK'),
+                            (($execResult->filesCommitted && $execResult->numFilesModified > 0) ? 'Modified ' . $execResult->numFilesModified . ' Files' : 'OK'),
+                            self::__($execResult->errorMessage),
+                        ));
+                    }
+                }
+            }
+            // Log any information.
+            if ($successes) {
+                self::log('info', $updateMode, self::__('Completed %s update task/s successfully. [ %s ]', array(
+                    count($successes),
+                    implode(', ', $successes),
+                )));
+            }
+            if ($warnings) {
+                self::log('warn', $updateMode, self::__('Encountered %s problem update task/s. [ %s ]', array(
+                    count($warnings),
+                    implode(', ', $warnings),
+                )));
+            }
+
+            return;
+        }
+        self::log('info', $updateMode, self::__('Nothing to update.'));
+    }
+
+    /**
+     * Log an update event for the extension.
+     *
+     * @param string $logMethod
+     * @param string $updateMode
+     * @param string $message
+     */
+    protected static function log($logMethod, $updateMode, $message)
+    {
+        /* @var $logger \TYPO3\CMS\Core\Log\Logger */
+        static $logger;
+        // Get a logger
+        if (! ($logger instanceof \TYPO3\CMS\Core\Log\Logger)) {
+            $logger = GeneralUtility::makeInstance('TYPO3\CMS\Core\Log\LogManager')->getLogger(__CLASS__);
+        }
+        if (method_exists($logger, $logMethod)) {
+            $logger->$logMethod(self::__('EXT: %s (v%s) %s-Update: ' . $message, array(
+                self::$EXTKEY,
+                self::$version,
+                ucfirst($updateMode),
+            )));
+        }
+    }
+
+    /**
+     * Translates extension text or returns the extension key or text.
+     *
+     * @param string $translation_key
+     * @param array $substitutions
+     * @return string
+     */
+    protected static function __($translation_key, $substitutions = array())
+    {
+        if ($translation_key !== null) {
+            // Check locallang_update.xlf translations first.
+            $llPath = 'LLL:EXT:' . self::$EXTKEY . '/Resources/Private/Language/locallang_update.xlf:';
+            $text = LocalizationUtility::translate($llPath . $translation_key, self::$EXTKEY, $substitutions);
+            // Try elsewhere (locallang.xlf)
+            if ($text == null || $text == '') {
+                $text = LocalizationUtility::translate($translation_key, self::$EXTKEY, $substitutions);
+            }
+
+            return ($text == null || $text == '') ? vsprintf($translation_key, $substitutions) : $text;
+        }
+
+        return '';
+    }
+}

--- a/Classes/Tools.php
+++ b/Classes/Tools.php
@@ -1,47 +1,44 @@
 <?php
+
 namespace Ecodev\Newsletter;
 
 use DateTime;
 use Ecodev\Newsletter\Domain\Model\Newsletter;
 
-/*
- * *************************************************************
- * Copyright notice
+/* * *************************************************************
+ *  Copyright notice
  *
- * (c) 2015
- * All rights reserved
+ *  (c) 2015
+ *  All rights reserved
  *
- * This script is part of the TYPO3 project. The TYPO3 project is
- * free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
  *
- * The GNU General Public License can be found at
- * http://www.gnu.org/copyleft/gpl.html.
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
  *
- * This script is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
  *
- * This copyright notice MUST APPEAR in all copies of the script!
- * *************************************************************
- */
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ * ************************************************************* */
 
 /**
  * Toolbox for newsletter and dependant extensions.
  *
  * @license http://www.gnu.org/licenses/gpl.html GNU General Public License, version 3 or later
  */
-abstract class Tools
+class Tools
 {
-
     protected static $configuration = null;
 
     /**
      * UriBuilder
-     *
      * @var \TYPO3\CMS\Extbase\Mvc\Web\Routing\UriBuilder
      */
     protected static $uriBuilder = null;
@@ -49,26 +46,12 @@ abstract class Tools
     /**
      * Get a newsletter-conf-template parameter
      *
-     * @param string $key
-     *            Parameter key
-     * @return mixed Parameter value
+     * @param    string   Parameter key
+     * @return   mixed    Parameter value
      */
     public static function confParam($key)
     {
-        // Look for a config in the module TS first.
-        static $configTS;
-        if (! is_array($configTS)) {
-            $objectManager = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('TYPO3\\CMS\\Extbase\\Object\\ObjectManager');
-            $beConfManager = $objectManager->get('TYPO3\\CMS\\Extbase\\Configuration\\BackendConfigurationManager');
-            $configTS = $beConfManager->getTypoScriptSetup();
-            $configTS = $configTS['module.']['tx_newsletter.']['config.'];
-        }
-        if (isset($configTS[$key])) {
-            return $configTS[$key];
-        }
-
-        // Else fallback to the extension config.
-        if (! is_array(self::$configuration)) {
+        if (!is_array(self::$configuration)) {
             self::$configuration = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['newsletter']);
         }
 
@@ -80,8 +63,7 @@ abstract class Tools
      *
      * @global \TYPO3\CMS\Core\Authentication\BackendUserAuthentication $BE_USER
      * @param string $message
-     * @param integer $logLevel
-     *            0 = message, 1 = error
+     * @param integer $logLevel 0 = message, 1 = error
      */
     public static function log($message, $logLevel = 0)
     {
@@ -95,8 +77,7 @@ abstract class Tools
      * Create a configured mailer from a newsletter page record.
      * This mailer will have both plain and html content applied as well as files attached.
      *
-     * @param \Ecodev\Newsletter\Domain\Model\Newsletter $newsletter
-     *            The newsletter
+     * @param \Ecodev\Newsletter\Domain\Model\Newsletter The newsletter
      * @param integer $language
      * @return \Ecodev\Newsletter\Mailer preconfigured mailer for sending
      */
@@ -119,6 +100,7 @@ abstract class Tools
 
     /**
      * Create the spool for all newsletters who need it
+     * @param boolean $onlyTest if true only test newsletter will be used, otherwise all (included tests)
      */
     public static function createAllSpool()
     {
@@ -135,8 +117,9 @@ abstract class Tools
      * Spool a newsletter page out to the real receivers.
      *
      * @global \TYPO3\CMS\Core\Database\DatabaseConnection $TYPO3_DB
-     * @param Newsletter $newsletter
-     * @return void
+     * @param   array        Newsletter record.
+     * @param   integer      Actual begin time.
+     * @return  void
      */
     public static function createSpool(Newsletter $newsletter)
     {
@@ -169,7 +152,7 @@ abstract class Tools
                     'pid' => $newsletter->getPid(),
                     'newsletter' => $newsletter->getUid(),
                 ));
-                $emailSpooledCount ++;
+                $emailSpooledCount++;
             }
         }
         self::log("Queued $emailSpooledCount emails to be sent for newsletter " . $newsletter->getUid());
@@ -206,8 +189,7 @@ abstract class Tools
     /**
      * Run the spool for one or all Newsletters
      *
-     * @param Newsletter $limitNewsletter
-     *            if specified, run spool only for that Newsletter
+     * @param Newsletter $limitNewsletter if specified, run spool only for that Newsletter
      */
     public static function runSpool(Newsletter $limitNewsletter = null)
     {
@@ -239,7 +221,7 @@ abstract class Tools
             $language = $recipientData['L'];
 
             // Was a language with this page defined, if not create one
-            if (! is_object($mailers[$language])) {
+            if (!is_object($mailers[$language])) {
                 $mailers[$language] = self::getConfiguredMailer($newsletter, $language);
             }
 
@@ -254,7 +236,7 @@ abstract class Tools
             $email->setEndTime(new DateTime());
             $emailRepository->updateNow($email);
 
-            $emailSentCount ++;
+            $emailSentCount++;
         }
 
         // Log numbers to syslog
@@ -263,7 +245,6 @@ abstract class Tools
 
     /**
      * Build an uriBuilder that can be used from any context (backend, frontend, TCA) to generate frontend URI
-     *
      * @param string $extensionName
      * @param string $pluginName
      * @return \TYPO3\CMS\Extbase\Mvc\Web\Routing\UriBuilder
@@ -272,8 +253,8 @@ abstract class Tools
     {
 
         // If we are in Backend we need to simulate minimal TSFE
-        if (! isset($GLOBALS['TSFE']) || ! ($GLOBALS['TSFE'] instanceof \TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController)) {
-            if (! is_object($GLOBALS['TT'])) {
+        if (!isset($GLOBALS['TSFE']) || !($GLOBALS['TSFE'] instanceof \TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController)) {
+            if (!is_object($GLOBALS['TT'])) {
                 $GLOBALS['TT'] = new \TYPO3\CMS\Core\TimeTracker\TimeTracker();
                 $GLOBALS['TT']->start();
             }
@@ -290,12 +271,9 @@ abstract class Tools
 
         // If extbase is not boostrapped yet, we must do it before building uriBuilder (when used from TCA)
         $objectManager = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('TYPO3\\CMS\\Extbase\\Object\\ObjectManager');
-        if (! (isset($GLOBALS['dispatcher']) && $GLOBALS['dispatcher'] instanceof \TYPO3\CMS\Extbase\Core\Bootstrap)) {
+        if (!(isset($GLOBALS['dispatcher']) && $GLOBALS['dispatcher'] instanceof \TYPO3\CMS\Extbase\Core\Bootstrap)) {
             $extbaseBootstrap = $objectManager->get('TYPO3\\CMS\\Extbase\\Core\\Bootstrap');
-            $extbaseBootstrap->initialize(array(
-                'extensionName' => $extensionName,
-                'pluginName' => $pluginName,
-            ));
+            $extbaseBootstrap->initialize(array('extensionName' => $extensionName, 'pluginName' => $pluginName));
         }
 
         return $objectManager->get('TYPO3\\CMS\\Extbase\\Mvc\\Web\\Routing\\UriBuilder');
@@ -303,18 +281,16 @@ abstract class Tools
 
     /**
      * Returns a frontend URI independently of current context, with or without extbase, and with or without TSFE
-     *
      * @param string $actionName
      * @param array $controllerArguments
      * @param string $controllerName
      * @param string $extensionName
      * @param string $pluginName
-     * @param array $otherArguments
      * @return string absolute URI
      */
-    public static function buildFrontendUri($actionName, array $controllerArguments, $controllerName, $extensionName = 'newsletter', $pluginName = 'p', array $otherArguments = null)
+    public static function buildFrontendUri($actionName, array $controllerArguments, $controllerName, $extensionName = 'newsletter', $pluginName = 'p')
     {
-        if (! self::$uriBuilder) {
+        if (!self::$uriBuilder) {
             self::$uriBuilder = self::buildUriBuilder($extensionName, $pluginName);
         }
         $controllerArguments['action'] = $actionName;
@@ -324,24 +300,19 @@ abstract class Tools
         $extensionService = $objectManager->get('TYPO3\\CMS\\Extbase\\Service\\ExtensionService');
         $pluginNamespace = $extensionService->getPluginNamespace($extensionName, $pluginName);
 
-        if (! isset($otherArguments) || is_null($otherArguments)) {
-            $otherArguments = array();
-        }
+        $arguments = array($pluginNamespace => $controllerArguments);
 
-        $arguments = $otherArguments;
-        $arguments[$pluginNamespace] = $controllerArguments;
-        self::$uriBuilder->reset()
-            ->setUseCacheHash(false)
-            ->setCreateAbsoluteUri(true)
-            ->setArguments($arguments)
-            ->setTargetPageType(1342671779);
+        self::$uriBuilder
+                ->reset()
+                ->setUseCacheHash(false)
+                ->setCreateAbsoluteUri(true)
+                ->setArguments($arguments);
 
-        return self::$uriBuilder->buildFrontendUri();
+        return self::$uriBuilder->buildFrontendUri() . '&type=1342671779';
     }
 
     /**
      * Returns an base64_encode encrypted string
-     *
      * @param string $string
      * @return string base64_encode encrypted string
      */
@@ -354,9 +325,7 @@ abstract class Tools
 
     /**
      * Returns a decrypted string
-     *
-     * @param string $string
-     *            base64_encode encrypted string
+     * @param string $string base64_encode encrypted string
      * @return string decrypted string
      */
     public static function decrypt($string)
@@ -370,13 +339,12 @@ abstract class Tools
 
     /**
      * Returns the size of the IV
-     *
      * @return integer
      */
     private static function getIVSize()
     {
         static $iv_size;
-        if (! isset($iv_size)) {
+        if (!isset($iv_size)) {
             $iv_size = mcrypt_get_iv_size(MCRYPT_RIJNDAEL_256, MCRYPT_MODE_CBC);
         }
 
@@ -385,13 +353,12 @@ abstract class Tools
 
     /**
      * Returns the secure encryption key
-     *
      * @return string
      */
     private static function getSecureKey()
     {
         static $secureKey;
-        if (! isset($secureKey)) {
+        if (!isset($secureKey)) {
             $secureKey = hash('sha256', $GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey'], true);
         }
 

--- a/Classes/Tools.php
+++ b/Classes/Tools.php
@@ -33,7 +33,7 @@ use Ecodev\Newsletter\Domain\Model\Newsletter;
  *
  * @license http://www.gnu.org/licenses/gpl.html GNU General Public License, version 3 or later
  */
-class Tools
+abstract class Tools
 {
     protected static $configuration = null;
 

--- a/Classes/Update.php
+++ b/Classes/Update.php
@@ -1,0 +1,146 @@
+<?php
+namespace Ecodev\Newsletter;
+
+use Ecodev\Newsletter\Update\Task;
+use Ecodev\Newsletter\Update\TaskResult;
+use Ecodev\Newsletter\Update\Transaction;
+
+/*
+ * *************************************************************
+ * Copyright notice
+ *
+ * (c) 2015
+ * All rights reserved
+ *
+ * This script is part of the TYPO3 project. The TYPO3 project is
+ * free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * The GNU General Public License can be found at
+ * http://www.gnu.org/copyleft/gpl.html.
+ *
+ * This script is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * This copyright notice MUST APPEAR in all copies of the script!
+ * *************************************************************
+ */
+
+/**
+ * Update for extensions
+ *
+ * @license http://www.gnu.org/licenses/gpl.html GNU General Public License, version 3 or later
+ * @author marvin-martian https://github.com/marvin-martian
+ */
+class Update extends AbstractUpdate
+{
+
+    /**
+     * Register update tasks.
+     */
+    public static function registerUpdateTasks()
+    {
+        // Register the updates you want to perform here:
+
+        // Notes on creating update tasks:
+        // 1) Set the version of the extension when this update was added.
+        // 2) Set whether the update tasks should be executed automatically (Task::AUTO_UPDATE) , manually via the Extension Manager(Task::MANUAL_UPDATE) or both (Task::UPDATE).
+        // 3) Add a short human description of your update.[A translation key is also accepted here.]
+        // 4) Set the callable \class::method path to execute the update.
+        // 5) [OPTIONAL] Set any arguments you wish to pass to your method in an array.
+
+        // Your Method MUST return a \Ecodev\Newsletter\Update\TaskResult on completion.
+        self::registerUpdateTask(new Task('2.3.0', Task::UPDATE, 'Migrate old class paths in newsletter records.', '\Ecodev\Newsletter\Update::updateTaskMigrateClassPathsInRecords'));
+        self::registerUpdateTask(new Task('2.5.2', Task::UPDATE, 'Encrypt plain-text bounce account passwords and configurations in newsletter records.', '\Ecodev\Newsletter\Update::updateTaskencryptOldBounceAccountPasswords'));
+    }
+
+    // Update Methods -- Optionally add your update methods below
+    // ////////////////////////////////////////////////////////////////////////////////////////////////////
+
+    // Notes: By using the Transaction:: methods you can get the data integrity state of your update operations.
+    // Also if something goes wrong your operations may have been reversed, protecting the users original data.
+
+    /**
+     * Migrate old class paths in DB records
+     *
+     * @return \Ecodev\Newsletter\Update\TaskResult
+     */
+    public static function updateTaskMigrateClassPathsInRecords()
+    {
+        // Init the Task Result
+        $taskResult = new TaskResult();
+
+        // Set Queries
+        $queries = array(
+            "UPDATE tx_scheduler_task SET serialized_task_object = REPLACE(serialized_task_object, 'O:29:\"Tx_Newsletter_Task_SendEmails\"', 'O:33:\"Ecodev\\\\Newsletter\\\\Task\\\\SendEmails\"');",
+            "UPDATE tx_scheduler_task SET serialized_task_object = REPLACE(serialized_task_object, 'O:31:\"Tx_Newsletter_Task_FetchBounces\"', 'O:35:\"Ecodev\\\\Newsletter\\\\Task\\\\FetchBounces\"');",
+            "UPDATE tx_newsletter_domain_model_recipientlist SET type = REPLACE(type, 'Tx_Newsletter_Domain_Model_RecipientList_', 'Ecodev\\\\Newsletter\\\\Domain\\\\Model\\\\RecipientList\\\\');",
+            "UPDATE tx_newsletter_domain_model_newsletter SET plain_converter = REPLACE(plain_converter, 'Tx_Newsletter_Domain_Model_PlainConverter_', 'Ecodev\\\\Newsletter\\\\Domain\\\\Model\\\\PlainConverter\\\\');",
+        );
+
+        // Execute Queries
+
+        // As this is post- newsletter version 2.5.2 the newsletter MyISAM tables have been already converted to InnoDB.
+        // So it is OK to do a InnoDB transaction here.
+
+        /* @var $transactedResults \Ecodev\Newsletter\Update\TransactionResult */
+        $transactedResults = Transaction::transactInnoDBQueries($queries);
+
+        // Set the Task outcomes.
+        $taskResult->success = $transactedResults->complete();
+        $taskResult->numRecordsModified = $transactedResults->getAffectedDataCount();
+        $taskResult->recordsCommitted = ! $transactedResults->getDataIntegrity();
+        $taskResult->errorMessage = $transactedResults->getErrorMessage();
+
+        return $taskResult;
+    }
+
+    /**
+     * Encrypt old bounce account passwords
+     *
+     * @global \TYPO3\CMS\Core\Database\DatabaseConnection $TYPO3_DB
+     * @return \Ecodev\Newsletter\Update\TaskResult
+     */
+    public static function updateTaskEncryptOldBounceAccountPasswords()
+    {
+        // Init the Task Result
+        $taskResult = new TaskResult();
+
+        // Prepare Queries
+        // Keep the old config to not break old installations
+        $config = Tools::encrypt("poll ###SERVER###\nproto ###PROTOCOL### \nusername \"###USERNAME###\"\npassword \"###PASSWORD###\"\n");
+
+        // Fetch and update the old records - they will have a default port and an empty config.
+        global $TYPO3_DB;
+        $rs = $TYPO3_DB->exec_SELECTquery('uid,password', 'tx_newsletter_domain_model_bounceaccount', 'port = 0 AND config = \'\'');
+        while (($records[] = $TYPO3_DB->sql_fetch_assoc($rs)) || array_pop($records));
+        $TYPO3_DB->sql_free_result($rs);
+
+        // Set Queries
+        $queries = array();
+        if (! empty($records)) {
+            foreach ($records as $row) {
+                $queries[] = $TYPO3_DB->UPDATEquery('tx_newsletter_domain_model_bounceaccount', 'uid=' . intval($row['uid']), array(
+                    'password' => Tools::encrypt($row['password']),
+                    'config' => $config,
+                ));
+            }
+        }
+
+        // Execute Queries
+        /* @var $transactedResults \Ecodev\Newsletter\Update\TransactionResult */
+        $transactedResults = Transaction::transactInnoDBQueries($queries);
+
+        // Set the Task outcomes.
+        $taskResult->success = $transactedResults->complete();
+        $taskResult->numRecordsModified = $transactedResults->getAffectedDataCount();
+        $taskResult->recordsCommitted = ! $transactedResults->getDataIntegrity();
+        $taskResult->errorMessage = $transactedResults->getErrorMessage();
+
+        return $taskResult;
+    }
+}

--- a/Classes/Update/Task.php
+++ b/Classes/Update/Task.php
@@ -1,0 +1,332 @@
+<?php
+namespace Ecodev\Newsletter\Update;
+
+/*
+ * *************************************************************
+ * Copyright notice
+ *
+ * (c) 2015
+ * All rights reserved
+ *
+ * This script is part of the TYPO3 project. The TYPO3 project is
+ * free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * The GNU General Public License can be found at
+ * http://www.gnu.org/copyleft/gpl.html.
+ *
+ * This script is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * This copyright notice MUST APPEAR in all copies of the script!
+ * *************************************************************
+ */
+
+/**
+ * A model for update tasks
+ *
+ * @license http://www.gnu.org/licenses/gpl.html GNU General Public License, version 3 or later
+ * @author marvin-martian https://github.com/marvin-martian
+ */
+class Task
+{
+
+    const AUTO_UPDATE = 'auto';
+
+    const MANUAL_UPDATE = 'manual';
+
+    const UPDATE = 'auto/manual';
+
+    /**
+     * Task Id
+     *
+     * @var string
+     */
+    protected $taskId;
+
+    /**
+     * The version of the extesnion when this update was added.
+     *
+     * @var string
+     */
+    protected $updateVersion;
+
+    /**
+     * Update mode of task
+     *
+     * @var string
+     */
+    protected $updateMode;
+
+    /**
+     * Current update mode of task
+     *
+     * @var string
+     */
+    protected $currentUpdateMode;
+
+    /**
+     * Task description
+     *
+     * @var string
+     */
+    protected $description;
+
+    /**
+     * Task update callable method
+     *
+     * @var string|array|false
+     */
+    protected $method;
+
+    /**
+     * Task arguments passed to method
+     *
+     * @var array
+     */
+    protected $methodArguments;
+
+    /**
+     * Task update status.
+     *
+     * @var boolean
+     */
+    protected $updated;
+
+    /**
+     * Last update time of task (UNIX Timestamp)
+     *
+     * @var integer
+     */
+    protected $lastUpdate;
+
+    /**
+     * Task execution result.
+     *
+     * @var \Ecodev\Newsletter\Update\TaskResult
+     */
+    protected $taskResult;
+
+    /**
+     * If the task is allowed to be executed.
+     *
+     * @var boolean
+     */
+    protected $executable;
+
+    /**
+     * If the task was executed.
+     *
+     * @var boolean
+     */
+    protected $executed;
+
+    /**
+     * Task model constructor
+     *
+     * @param string $updateVersion
+     *            The extension version of when this update task was added.
+     * @param string $updateMode
+     *            The update mode of the task (Task::AUTO_UPDATE|Task::MANUAL_UPDATE|Task::UPDATE) [DEFAULT: Task::UPDATE]
+     * @param string $description
+     *            Short human readable description of the update task, can also be a translation key.
+     * @param string $methodPath
+     *            The callable method path of the update task.
+     * @param array $methodArguments
+     *            An array of arguments you wish to pass to the update method. [OPTIONAL]
+     */
+    public function __construct($updateVersion = '', $updateMode = 'auto/manual', $description = '', $methodPath = '', $methodArguments = array())
+    {
+        $tempArgs = func_get_args();
+        unset($tempArgs[1]);
+        $this->taskId = md5(serialize($tempArgs));
+        $this->updateVersion = $updateVersion;
+        $this->updateMode = $updateMode;
+        $this->description = $description;
+        $this->method = $this->getCallableMethod($methodPath);
+        $this->methodArguments = $methodArguments;
+        $this->executable = (boolean) $this->method;
+        $this->executed = false;
+        $this->updated = false;
+        $this->lastUpdate = - 1;
+    }
+
+    /**
+     * Returns the task id.
+     *
+     * @return string
+     */
+    public function getTaskId()
+    {
+        return $this->taskId;
+    }
+
+    /**
+     * Returns the task update mode.
+     *
+     * @return string
+     */
+    public function getTaskType()
+    {
+        return $this->updateMode;
+    }
+
+    /**
+     * Returns the update version
+     */
+    public function getUpdateVersion()
+    {
+        return $this->updateVersion;
+    }
+
+    /**
+     * Returns the task description
+     */
+    public function getDescription()
+    {
+        return $this->description;
+    }
+
+    /**
+     * Returns the update mode
+     */
+    public function getUpdateMode()
+    {
+        return $this->updateMode;
+    }
+
+    /**
+     * Sets the current update mode.
+     *
+     * @param string $currentUpdateMode
+     */
+    public function setCurrentUpdateMode($currentUpdateMode)
+    {
+        $this->currentUpdateMode = $currentUpdateMode;
+    }
+
+    /**
+     * Returns the update method
+     */
+    public function getUpdateMethod()
+    {
+        return $this->method;
+    }
+
+    /**
+     * Sets the update status of the task.
+     *
+     * @param array $updateHistory
+     */
+    public function setStatus($updateHistory)
+    {
+        $this->updated = (boolean) isset($updateHistory[$this->taskId]);
+        $this->lastUpdate = $this->updated ? $updateHistory[$this->taskId] : - 1;
+    }
+
+    /**
+     * Retrieves the update status of the task.
+     *
+     * @return boolean
+     */
+    public function isUpdated()
+    {
+        return $this->updated;
+    }
+
+    /**
+     * Sets/Gets the execution status of the task.
+     *
+     * @param boolean $execute
+     * @return boolean
+     */
+    public function canExecute($execute = null)
+    {
+        if (isset($execute) && ! is_null($execute)) {
+            $this->executable = (boolean) $execute;
+        }
+
+        return $this->executable;
+    }
+
+    /**
+     * Returns if the task was executed.
+     *
+     * @return boolean
+     */
+    public function wasExecuted()
+    {
+        return $this->executed;
+    }
+
+    /**
+     * Gets the last updatetime of the task.
+     *
+     * @return integer UNIX Timestamp
+     */
+    public function getLastUpdate()
+    {
+        return $this->lastUpdate;
+    }
+
+    /**
+     * Executes the task method.
+     *
+     * @return boolean TRUE on success, FALSE on non-execution
+     */
+    public function execTask()
+    {
+        $this->executed = false;
+        // Automatic tasks are only run once.
+        if ($this->currentUpdateMode == self::AUTO_UPDATE && $this->updated) {
+            return $this->executed;
+        }
+
+        if ($this->method) {
+            $result = call_user_func_array($this->method, $this->methodArguments);
+            if ($result instanceof \Ecodev\Newsletter\Update\TaskResult) {
+                $result->executionTime = time();
+                $this->executed = true;
+                $this->taskResult = $result;
+                $this->lastUpdate = $result->executionTime;
+            }
+        }
+
+        return $this->executed;
+    }
+
+    /**
+     * Returns the result of the task execution.
+     *
+     * @return \Ecodev\Newsletter\Update\TaskResult
+     */
+    public function getExecResult()
+    {
+        return $this->taskResult;
+    }
+
+    /**
+     * Returns a callable method
+     *
+     * @param string $methodPath
+     * @return string|array|boolean Returns a callable method as string or array or FALSE on failure.
+     */
+    protected function getCallableMethod($methodPath)
+    {
+        if (version_compare(PHP_VERSION, '5.2.3') < 0) {
+            $hasPaamayimNekudotayim = strpos($methodPath, '::');
+            if (! ($hasPaamayimNekudotayim === false) && $hasPaamayimNekudotayim > 0) {
+                $methodPath = explode($methodPath, '::');
+            }
+        }
+        if (is_callable($methodPath)) {
+            return $methodPath;
+        }
+
+        return false;
+    }
+}

--- a/Classes/Update/TaskResult.php
+++ b/Classes/Update/TaskResult.php
@@ -1,0 +1,106 @@
+<?php
+namespace Ecodev\Newsletter\Update;
+
+/*
+ * *************************************************************
+ * Copyright notice
+ *
+ * (c) 2015
+ * All rights reserved
+ *
+ * This script is part of the TYPO3 project. The TYPO3 project is
+ * free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * The GNU General Public License can be found at
+ * http://www.gnu.org/copyleft/gpl.html.
+ *
+ * This script is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * This copyright notice MUST APPEAR in all copies of the script!
+ * *************************************************************
+ */
+
+/**
+ * A model for update task results
+ *
+ * @license http://www.gnu.org/licenses/gpl.html GNU General Public License, version 3 or later
+ * @author marvin-martian https://github.com/marvin-martian
+ */
+class TaskResult
+{
+
+    /**
+     * Whether the task was a success or not
+     *
+     * @var boolean
+     */
+    public $success = false;
+
+    /**
+     * A human result message.
+     *
+     * @var string
+     */
+    public $errorMessage = '';
+
+    /**
+     * The number of database records modified in the update.
+     *
+     * @var integer
+     */
+    public $numRecordsModified = 0;
+
+    /**
+     * State of whether database records were modified (added,deleted or updated) by the update.
+     *
+     * @var boolean
+     */
+    public $recordsCommitted = false;
+
+    /**
+     * The number of files modified (added,deleted or updated)in the update.
+     *
+     * @var integer
+     */
+    public $numFilesModified = 0;
+
+    /**
+     * State of whether files were modified (added,deleted or updated) by the update.
+     *
+     * @var boolean
+     */
+    public $filesCommitted = false;
+
+    /**
+     * The execution time (UNIX TIMSTAMP) of the task.
+     *
+     * @var integer
+     */
+    public $executionTime = -1;
+
+    /**
+     * Task results model constructor
+     *
+     * @param boolean $success
+     * @param string $errorMessage
+     * @param integer $numRecordsModified
+     * @param boolean $recordsCommitted
+     * @param integer $numFilesModified
+     * @param boolean $filesCommitted
+     */
+    public function __construct($success = false, $errorMessage = '', $numRecordsModified = 0, $recordsCommitted = false, $numFilesModified = 0, $filesCommitted = false)
+    {
+        $this->success = $success;
+        $this->errorMessage = $errorMessage;
+        $this->numRecordsModified = $numRecordsModified;
+        $this->recordsCommitted = $recordsCommitted;
+        $this->numFilesModified = $numFilesModified;
+        $this->filesCommitted = $filesCommitted;
+    }
+}

--- a/Classes/Update/Transaction.php
+++ b/Classes/Update/Transaction.php
@@ -1,0 +1,115 @@
+<?php
+namespace Ecodev\Newsletter\Update;
+
+/*
+ * *************************************************************
+ * Copyright notice
+ *
+ * (c) 2015
+ * All rights reserved
+ *
+ * This script is part of the TYPO3 project. The TYPO3 project is
+ * free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * The GNU General Public License can be found at
+ * http://www.gnu.org/copyleft/gpl.html.
+ *
+ * This script is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * This copyright notice MUST APPEAR in all copies of the script!
+ * *************************************************************
+ */
+
+/**
+ * A collection of transacted operations.
+ *
+ * @license http://www.gnu.org/licenses/gpl.html GNU General Public License, version 3 or later
+ * @author marvin-martian https://github.com/marvin-martian
+ */
+class Transaction
+{
+
+    /**
+     * Executes an array of of INNODB queries wrapped in a transaction.
+     * WARNING: Only works with InnoDB tables and DOES NOT CHECK the table type!!!
+     * I am assuming you know what queries you are throwing into this method.
+     *
+     * @global \TYPO3\CMS\Core\Database\DatabaseConnection $TYPO3_DB
+     * @param array $queries
+     *            An array of SQL queries.
+     * @return \Ecodev\Newsletter\Update\TransactionResult
+     */
+    public static function transactInnoDBQueries(array $queries)
+    {
+        $results = new TransactionResult(count($queries));
+        if (! empty($queries)) {
+            global $TYPO3_DB;
+            // By wrapping the queries in a transaction we can rollback if
+            // something goes wrong and not destroy the users data in the process.
+            // WARNING: Only works with InnoDB tables and DOES NOT CHECK the table type!!!
+            $TYPO3_DB->sql_query("START TRANSACTION;");
+            $results = self::transactDBQueries($queries);
+            if ($results->getErrorMessage()) {
+                $TYPO3_DB->sql_query("ROLLBACK;");
+                // Because we rolled back nothing was modified so we can safely reset the integrity state.
+                $results->resetDataIntegrity();
+
+                return $results;
+            }
+            $TYPO3_DB->sql_query("COMMIT;");
+        }
+
+        return $results;
+    }
+
+    /**
+     * Executes an array of database queries.
+     *
+     * @global \TYPO3\CMS\Core\Database\DatabaseConnection $TYPO3_DB
+     * @param array $queries
+     *            An array of SQL queries.
+     * @return \Ecodev\Newsletter\Update\TransactionResult
+     */
+    public static function transactDBQueries(array $queries)
+    {
+        $results = new TransactionResult(count($queries));
+        if (! empty($queries)) {
+            global $TYPO3_DB;
+            foreach ($queries as $query) {
+                $res = $TYPO3_DB->sql_query($query);
+                $results->appendAffectedDataCount($TYPO3_DB->sql_affected_rows($res));
+                $error = $TYPO3_DB->sql_error();
+                if ($error) {
+                    $results->setErrorMessage($error);
+                    break;
+                }
+                $results->stepProcessed();
+            }
+            $TYPO3_DB->sql_free_result($res);
+        }
+
+        return $results;
+    }
+
+    /**
+     * Transacts a list of file operations, on encountering an error ALL operations are rolled back to their previous state (if possible).
+     *
+     * @param array $operands
+     * @return \Ecodev\Newsletter\Update\TransactionResult
+     */
+    public static function transactFileOperands(array $operands)
+    {
+        $results = new TransactionResult(count($operands));
+        if (! empty($operands)) {
+            // @todo transactFileOperands
+        }
+
+        return $results;
+    }
+}

--- a/Classes/Update/TransactionResult.php
+++ b/Classes/Update/TransactionResult.php
@@ -1,0 +1,172 @@
+<?php
+namespace Ecodev\Newsletter\Update;
+
+/*
+ * *************************************************************
+ * Copyright notice
+ *
+ * (c) 2015
+ * All rights reserved
+ *
+ * This script is part of the TYPO3 project. The TYPO3 project is
+ * free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * The GNU General Public License can be found at
+ * http://www.gnu.org/copyleft/gpl.html.
+ *
+ * This script is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * This copyright notice MUST APPEAR in all copies of the script!
+ * *************************************************************
+ */
+
+/**
+ * A model for transaction states of operands
+ *
+ * @license http://www.gnu.org/licenses/gpl.html GNU General Public License, version 3 or later
+ * @author marvin-martian https://github.com/marvin-martian
+ */
+class TransactionResult
+{
+
+    /**
+     * Whether the transaction was completed or not
+     *
+     * @var boolean
+     */
+    protected $completed = false;
+
+    /**
+     * Error message associated with transaction.
+     *
+     * @var string
+     */
+    protected $errorMessage;
+
+    /**
+     * The integrity state of whether or not data was modified.
+     * A value TRUE means it was not modified.
+     *
+     * @var boolean
+     */
+    protected $dataIntegrity = true;
+
+    /**
+     * The number of data instances affected by the transaction.
+     *
+     * @var integer
+     */
+    protected $affectedDataCount = 0;
+
+    /**
+     * The total number of operands in the transaction.
+     *
+     * @var integer
+     */
+    protected $totalOperands = 0;
+
+    /**
+     * The number of operands processed in the transaction.
+     *
+     * @var integer
+     */
+    protected $processedOperands = 0;
+
+    /**
+     * Transaction state constructor.
+     *
+     * @param number $totalOperands
+     */
+    public function __construct($totalOperands = 0)
+    {
+        $this->totalOperands = $totalOperands;
+        $this->completed = ($this->processedOperands >= $this->totalOperands);
+        $this->dataIntegrity = ($this->affectedDataCount == 0);
+    }
+
+    /**
+     * Steps the count of processed operands and updates the transaction complete state.
+     */
+    public function stepProcessed()
+    {
+        $this->processedOperands ++;
+        $this->completed = ($this->processedOperands >= $this->totalOperands);
+    }
+
+    /**
+     * Error message setter.
+     *
+     * @param string $message
+     */
+    public function setErrorMessage($message)
+    {
+        $this->errorMessage = $message;
+    }
+
+    /**
+     * Error message getter
+     *
+     * @return string
+     */
+    public function getErrorMessage()
+    {
+        return $this->errorMessage;
+    }
+
+    /**
+     * The complete state of the transaction.
+     *
+     * @return boolean
+     */
+    public function complete()
+    {
+        return $this->completed;
+    }
+
+    /**
+     * Affected data count getter.
+     *
+     * @return integer
+     */
+    public function getAffectedDataCount()
+    {
+        return $this->affectedDataCount;
+    }
+
+    /**
+     * Appends the count of affected data.
+     *
+     * @param integer $amount
+     */
+    public function appendAffectedDataCount($amount)
+    {
+        $this->affectedDataCount += $amount;
+        $this->dataIntegrity = ($this->affectedDataCount == 0);
+    }
+
+    /**
+     * Resets the data integrity.
+     */
+    public function resetDataIntegrity()
+    {
+        $this->affectedDataCount = 0;
+        $this->dataIntegrity = ($this->affectedDataCount == 0);
+    }
+
+    /**
+     * Returns the integrity state of whether or not data was modified.
+     * A value TRUE means it was not modified and the data remains integral.
+     *
+     * @return boolean
+     */
+    public function getDataIntegrity()
+    {
+        return $this->dataIntegrity;
+    }
+}

--- a/Resources/Private/Language/de.locallang_update.xlf
+++ b/Resources/Private/Language/de.locallang_update.xlf
@@ -1,0 +1,86 @@
+<?xml version='1.0' encoding='utf-8'?>
+<xliff version="1.0">
+    <file source-language="en" target-language="de" datatype="plaintext" original="messages" date="2015-08-22T16:21:05Z" product-name="newsletter">
+        <header/>
+        <body>
+            <trans-unit id="ext-update.manual_updates" xml:space="preserve" approved="yes">
+                <source>Manual Updates</source>
+            <target state="translated">Manuelle Updates</target></trans-unit>
+            <trans-unit id="ext-update.select_manual_tasks" xml:space="preserve" approved="yes">
+                <source>Select the update tasks you wish to manually apply.</source>
+            <target state="translated">Wählen Sie die Update-Aufgaben, die Sie manuell anwenden möchten.</target></trans-unit>
+            <trans-unit id="ext-update.new_install_advice" xml:space="preserve" approved="yes">
+                <source>If this is a new install of the extension, manually updating may not be necessary.</source>
+            <target state="translated">Falls dies eine Neuinstallation der Erweiterung ist, ist eine manuellen Aktualisierung eventuell nicht notwendig.</target></trans-unit>
+            <trans-unit id="ext-update.current_version" xml:space="preserve" approved="yes">
+                <source>Current Extension Version: %s</source>
+            <target state="translated">Aktuelle Extension Version: %s</target></trans-unit>
+            <trans-unit id="ext-update.update_tasks" xml:space="preserve" approved="yes">
+                <source>Update Tasks</source>
+            <target state="translated">Update-Aufgaben</target></trans-unit>
+            <trans-unit id="ext-update.task" xml:space="preserve" approved="yes">
+                <source>Task</source>
+            <target state="translated">Aufgabe</target></trans-unit>
+            <trans-unit id="ext-update.since" xml:space="preserve" approved="yes">
+                <source>Since</source>
+            <target state="translated">Seit</target></trans-unit>
+            <trans-unit id="ext-update.update_type" xml:space="preserve" approved="yes">
+                <source>Update-Type</source>
+            <target state="translated">Update Typ</target></trans-unit>
+            <trans-unit id="ext-update.last_updated" xml:space="preserve" approved="yes">
+                <source>Last-Updated</source>
+            <target state="translated">Letzte Aktualisierung</target></trans-unit>
+            <trans-unit id="ext-update.ago" xml:space="preserve" approved="yes">
+                <source>%s ago</source>
+            <target state="translated">Vor %s</target></trans-unit>
+            <trans-unit id="ext-update.never" xml:space="preserve" approved="yes">
+                <source>never</source>
+            <target state="translated">niemals</target></trans-unit>
+            <trans-unit id="ext-update.update_selected" xml:space="preserve" approved="yes">
+                <source>Update Selected</source>
+            <target state="translated">Aktualisieren</target></trans-unit>
+            <trans-unit id="ext-update.update_results" xml:space="preserve" approved="yes">
+                <source>Update Results</source>
+            <target state="translated">Update-Ergebnisse</target></trans-unit>
+            <trans-unit id="ext-update.records_modified" xml:space="preserve" approved="yes">
+                <source>Records-Modified</source>
+            <target state="translated">Veränderte Einträge</target></trans-unit>
+            <trans-unit id="ext-update.files_modified" xml:space="preserve" approved="yes">
+                <source>Files-Modified</source>
+            <target state="translated">Files-Modified</target></trans-unit>
+            <trans-unit id="ext-update.problems" xml:space="preserve" approved="yes">
+                <source>Problems</source>
+            <target state="translated">Probleme</target></trans-unit>
+            <trans-unit id="ext-update.none" xml:space="preserve" approved="yes">
+                <source>none</source>
+            <target state="translated">keine</target></trans-unit>
+            <trans-unit id="ext-update.attention" xml:space="preserve" approved="yes">
+                <source>Attention</source>
+            <target state="translated">Achtung</target></trans-unit>
+            <trans-unit id="ext-update.no_tasks_selected" xml:space="preserve" approved="yes">
+                <source>No update tasks selected.</source>
+            <target state="translated">Keine Update-Aufgaben ausgewählt.</target></trans-unit>
+            <trans-unit id="ext-update.all_updates_completed_successfully" xml:space="preserve" approved="yes">
+                <source>All selected update tasks completed successfully.</source>
+            <target state="translated">Alle ausgewählten Update-Aufgaben wurden erfolgreich abgeschlossen.</target></trans-unit>
+            <trans-unit id="ext-update.update_success" xml:space="preserve" approved="yes">
+                <source>Update Success</source>
+            <target state="translated">Update Success</target></trans-unit>
+            <trans-unit id="ext-update.some_update_problems_but_data_integrity_kept" xml:space="preserve" approved="yes">
+                <source>There was some problems with some of the selected update tasks, however your record and file integrity is the same as before you updated.</source>
+            <target state="translated">Es gab einige Probleme mit ausgewählten Update-Aufgaben. Ihr Datensatz und seine Vollständigkeit wurden jedoch nicht verändert.</target></trans-unit>
+            <trans-unit id="ext-update.please_review_update_results_below" xml:space="preserve" approved="yes">
+                <source>Please review the Update Results below for further information.</source>
+            <target state="translated">Bitte überprüfen Sie die untenstehenden Update-Ergebnisse für weitere Informationen.</target></trans-unit>
+            <trans-unit id="ext-update.update_warning" xml:space="preserve" approved="yes">
+                <source>Update Warning</source>
+            <target state="translated">Update Warnung</target></trans-unit>
+            <trans-unit id="ext-update.some_critical_update_problems" xml:space="preserve" approved="yes">
+                <source>There was some critical problems with some of the selected update tasks, some files or records may have been irreversibly modified. We hope you have a backup.</source>
+            <target state="translated">Es gab einige kritische Probleme mit ausgewählten Update-Aufgaben. Einige Dateien oder Aufzeichnungen könnten irreversibel verändert worden sein. Wir hoffen, dass Sie ein Backup haben.</target></trans-unit>
+            <trans-unit id="ext-update.update_error" xml:space="preserve" approved="yes">
+                <source>Update Error</source>
+            <target state="translated">Update Fehler</target></trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/Resources/Private/Language/fr.locallang_update.xlf
+++ b/Resources/Private/Language/fr.locallang_update.xlf
@@ -1,0 +1,86 @@
+<?xml version='1.0' encoding='utf-8'?>
+<xliff version="1.0">
+    <file source-language="en" target-language="fr" datatype="plaintext" original="messages" date="2015-08-22T16:21:05Z" product-name="newsletter">
+        <header/>
+        <body>
+            <trans-unit id="ext-update.manual_updates" xml:space="preserve" approved="yes">
+                <source>Manual Updates</source>
+            <target state="translated">Actualisé Manuel</target></trans-unit>
+            <trans-unit id="ext-update.select_manual_tasks" xml:space="preserve" approved="yes">
+                <source>Select the update tasks you wish to manually apply.</source>
+            <target state="translated">Sélectionnez les tâches de mise à jour que vous souhaitez appliquer manuellement.</target></trans-unit>
+            <trans-unit id="ext-update.new_install_advice" xml:space="preserve" approved="yes">
+                <source>If this is a new install of the extension, manually updating may not be necessary.</source>
+            <target state="translated">Si cela est une nouvelle installation de l'extension, mise à jour manuelle peut ne pas être nécessaire.</target></trans-unit>
+            <trans-unit id="ext-update.current_version" xml:space="preserve" approved="yes">
+                <source>Current Extension Version: %s</source>
+            <target state="translated">Extension version actuelle : %s</target></trans-unit>
+            <trans-unit id="ext-update.update_tasks" xml:space="preserve" approved="yes">
+                <source>Update Tasks</source>
+            <target state="translated">Actualiser Tâches</target></trans-unit>
+            <trans-unit id="ext-update.task" xml:space="preserve" approved="yes">
+                <source>Task</source>
+            <target state="translated">Tâche</target></trans-unit>
+            <trans-unit id="ext-update.since" xml:space="preserve" approved="yes">
+                <source>Since</source>
+            <target state="translated">Depuis</target></trans-unit>
+            <trans-unit id="ext-update.update_type" xml:space="preserve" approved="yes">
+                <source>Update-Type</source>
+            <target state="translated">Actualisez-Type</target></trans-unit>
+            <trans-unit id="ext-update.last_updated" xml:space="preserve" approved="yes">
+                <source>Last-Updated</source>
+            <target state="translated">Dernier-Actualisé</target></trans-unit>
+            <trans-unit id="ext-update.ago" xml:space="preserve" approved="yes">
+                <source>%s ago</source>
+            <target state="translated">Il ya %s</target></trans-unit>
+            <trans-unit id="ext-update.never" xml:space="preserve" approved="yes">
+                <source>never</source>
+            <target state="translated">jamais</target></trans-unit>
+            <trans-unit id="ext-update.update_selected" xml:space="preserve" approved="yes">
+                <source>Update Selected</source>
+            <target state="translated">Actualisé sélectionné</target></trans-unit>
+            <trans-unit id="ext-update.update_results" xml:space="preserve" approved="yes">
+                <source>Update Results</source>
+            <target state="translated">Résultats actuels</target></trans-unit>
+            <trans-unit id="ext-update.records_modified" xml:space="preserve" approved="yes">
+                <source>Records-Modified</source>
+            <target state="translated">Dossiers modifiés</target></trans-unit>
+            <trans-unit id="ext-update.files_modified" xml:space="preserve" approved="yes">
+                <source>Files-Modified</source>
+            <target state="translated">Fichiers modifiés</target></trans-unit>
+            <trans-unit id="ext-update.problems" xml:space="preserve" approved="yes">
+                <source>Problems</source>
+            <target state="translated">Problèmes</target></trans-unit>
+            <trans-unit id="ext-update.none" xml:space="preserve" approved="yes">
+                <source>none</source>
+            <target state="translated">nul</target></trans-unit>
+            <trans-unit id="ext-update.attention" xml:space="preserve" approved="yes">
+                <source>Attention</source>
+            <target state="translated">Attention</target></trans-unit>
+            <trans-unit id="ext-update.no_tasks_selected" xml:space="preserve" approved="yes">
+                <source>No update tasks selected.</source>
+            <target state="translated">Aucune tâche de Actualisé sélectionnés.</target></trans-unit>
+            <trans-unit id="ext-update.all_updates_completed_successfully" xml:space="preserve" approved="yes">
+                <source>All selected update tasks completed successfully.</source>
+            <target state="translated">Toutes les tâches actualisées sélectionnés complété avec succès.</target></trans-unit>
+            <trans-unit id="ext-update.update_success" xml:space="preserve" approved="yes">
+                <source>Update Success</source>
+            <target state="translated">Succès</target></trans-unit>
+            <trans-unit id="ext-update.some_update_problems_but_data_integrity_kept" xml:space="preserve" approved="yes">
+                <source>There was some problems with some of the selected update tasks, however your record and file integrity is the same as before you updated.</source>
+            <target state="translated">Il y avait quelques problèmes avec certaines des tâches d'actualiser sélectionnés, mais votre dossier de base de données et l'intégrité des fichiers est le même que avant actualisé.</target></trans-unit>
+            <trans-unit id="ext-update.please_review_update_results_below" xml:space="preserve" approved="yes">
+                <source>Please review the Update Results below for further information.</source>
+            <target state="translated">S'il vous plaît examiner les résultats ci-dessous actualisé pour plus d'informations.</target></trans-unit>
+            <trans-unit id="ext-update.update_warning" xml:space="preserve" approved="yes">
+                <source>Update Warning</source>
+            <target state="translated">Avertissement</target></trans-unit>
+            <trans-unit id="ext-update.some_critical_update_problems" xml:space="preserve" approved="yes">
+                <source>There was some critical problems with some of the selected update tasks, some files or records may have been irreversibly modified. We hope you have a backup.</source>
+            <target state="translated">Il y avait quelques problèmes critiques avec quelques-unes des tâches de Actualize sélectionnés, certains fichiers ou dossiers peuvent avoir été modifiées de façon irréversible. Nous espérons que vous avez une sauvegarde.</target></trans-unit>
+            <trans-unit id="ext-update.update_error" xml:space="preserve" approved="yes">
+                <source>Update Error</source>
+            <target state="translated">Erreur</target></trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/Resources/Private/Language/locallang_update.xlf
+++ b/Resources/Private/Language/locallang_update.xlf
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
+<xliff version="1.0">
+    <file source-language="en" datatype="plaintext" original="messages" date="2015-08-22T16:21:05Z" product-name="newsletter">
+        <header/>
+        <body>
+            <trans-unit id="ext-update.manual_updates" xml:space="preserve">
+                <source>Manual Updates</source>
+            </trans-unit>
+            <trans-unit id="ext-update.select_manual_tasks" xml:space="preserve">
+                <source>Select the update tasks you wish to manually apply.</source>
+            </trans-unit>
+            <trans-unit id="ext-update.new_install_advice" xml:space="preserve">
+                <source>If this is a new install of the extension, manually updating may not be necessary.</source>
+            </trans-unit>
+            <trans-unit id="ext-update.current_version" xml:space="preserve">
+                <source>Current Extension Version: %s</source>
+            </trans-unit>
+            <trans-unit id="ext-update.update_tasks" xml:space="preserve">
+                <source>Update Tasks</source>
+            </trans-unit>
+            <trans-unit id="ext-update.task" xml:space="preserve">
+                <source>Task</source>
+            </trans-unit>
+            <trans-unit id="ext-update.since" xml:space="preserve">
+                <source>Since</source>
+            </trans-unit>
+            <trans-unit id="ext-update.update_type" xml:space="preserve">
+                <source>Update-Type</source>
+            </trans-unit>
+            <trans-unit id="ext-update.last_updated" xml:space="preserve">
+                <source>Last-Updated</source>
+            </trans-unit>
+            <trans-unit id="ext-update.ago" xml:space="preserve">
+                <source>%s ago</source>
+            </trans-unit>
+            <trans-unit id="ext-update.never" xml:space="preserve">
+                <source>never</source>
+            </trans-unit>
+            <trans-unit id="ext-update.update_selected" xml:space="preserve">
+                <source>Update Selected</source>
+            </trans-unit>
+            <trans-unit id="ext-update.update_results" xml:space="preserve">
+                <source>Update Results</source>
+            </trans-unit>
+            <trans-unit id="ext-update.records_modified" xml:space="preserve">
+                <source>Records-Modified</source>
+            </trans-unit>
+            <trans-unit id="ext-update.files_modified" xml:space="preserve">
+                <source>Files-Modified</source>
+            </trans-unit>
+            <trans-unit id="ext-update.problems" xml:space="preserve">
+                <source>Problems</source>
+            </trans-unit>
+            <trans-unit id="ext-update.none" xml:space="preserve">
+                <source>none</source>
+            </trans-unit>
+            <trans-unit id="ext-update.attention" xml:space="preserve">
+                <source>Attention</source>
+            </trans-unit>
+            <trans-unit id="ext-update.no_tasks_selected" xml:space="preserve">
+                <source>No update tasks selected.</source>
+            </trans-unit>
+            <trans-unit id="ext-update.all_updates_completed_successfully" xml:space="preserve">
+                <source>All selected update tasks completed successfully.</source>
+            </trans-unit>
+            <trans-unit id="ext-update.update_success" xml:space="preserve">
+                <source>Update Success</source>
+            </trans-unit>
+            <trans-unit id="ext-update.some_update_problems_but_data_integrity_kept" xml:space="preserve">
+                <source>There was some problems with some of the selected update tasks, however your record and file integrity is the same as before you updated.</source>
+            </trans-unit>
+            <trans-unit id="ext-update.please_review_update_results_below" xml:space="preserve">
+                <source>Please review the Update Results below for further information.</source>
+            </trans-unit>
+            <trans-unit id="ext-update.update_warning" xml:space="preserve">
+                <source>Update Warning</source>
+            </trans-unit>
+            <trans-unit id="ext-update.some_critical_update_problems" xml:space="preserve">
+                <source>There was some critical problems with some of the selected update tasks, some files or records may have been irreversibly modified. We hope you have a backup.</source>
+            </trans-unit>
+            <trans-unit id="ext-update.update_error" xml:space="preserve">
+                <source>Update Error</source>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/class.ext_update.php
+++ b/class.ext_update.php
@@ -31,70 +31,20 @@
 class ext_update
 {
     /**
-     * SQL queries to do migration
-     * @var array
-     */
-    private $queries = array(
-        "UPDATE tx_scheduler_task SET serialized_task_object = REPLACE(serialized_task_object, 'O:29:\"Tx_Newsletter_Task_SendEmails\"', 'O:33:\"Ecodev\\\\Newsletter\\\\Task\\\\SendEmails\"');",
-        "UPDATE tx_scheduler_task SET serialized_task_object = REPLACE(serialized_task_object, 'O:31:\"Tx_Newsletter_Task_FetchBounces\"', 'O:35:\"Ecodev\\\\Newsletter\\\\Task\\\\FetchBounces\"');",
-        "UPDATE tx_newsletter_domain_model_recipientlist SET type = REPLACE(type, 'Tx_Newsletter_Domain_Model_RecipientList_', 'Ecodev\\\\Newsletter\\\\Domain\\\\Model\\\\RecipientList\\\\');",
-        "UPDATE tx_newsletter_domain_model_newsletter SET plain_converter = REPLACE(plain_converter, 'Tx_Newsletter_Domain_Model_PlainConverter_', 'Ecodev\\\\Newsletter\\\\Domain\\\\Model\\\\PlainConverter\\\\');",
-    );
-
-    /**
      * Main function, returning the HTML content of the module
      * @return	string HTML to display
      */
     public function main()
     {
-        $content = '';
-        $content .= '<h2>Migration from Newsletter 2.2.3 to 2.3.0</h2>';
-        $content .= '<form name="migrateForm" action="" method ="post">';
-        $content .= '<p>Records in database from Newsletter 2.2.3, or earlier, will be migrated to 2.3.0, or later. This action is idempotent and can be repeated if necessary.</p>';
-        $content .= '<p><input type="submit" name="domigration" value ="Migrate" /></p>';
-        $content .= '</form>';
-
-        // Action! Makes the necessary update
-        $update = \TYPO3\CMS\Core\Utility\GeneralUtility::_GP('domigration');
-
-        // The update button was clicked, migrate stuff
-        if (!empty($update)) {
-            $recordCount = $this->doMigration();
-            $content .= '<h3>Results</h3>';
-            $content .= "<p>$recordCount records successfully migrated.</p>";
-        }
-
-        return $content;
-    }
-
-    /**
-     * Apply the migration
-     * @global \TYPO3\CMS\Core\Database\DatabaseConnection $TYPO3_DB
-     */
-    private function doMigration()
-    {
-        global $TYPO3_DB;
-
-        $recordCount = 0;
-        foreach ($this->queries as $query) {
-            $res = $TYPO3_DB->sql_query($query);
-            $error = $TYPO3_DB->sql_error();
-            if ($error) {
-                die("<pre>" . $query . "<br>" . $error . "</pre>");
-            }
-            $recordCount += $TYPO3_DB->sql_affected_rows($res);
-        }
-
-        return $recordCount;
+        return \Ecodev\Newsletter\Update::main();
     }
 
     /**
      * This method checks whether it is necessary to display the UPDATE option at all
-     *
-     * @param string $what What should be updated
+     * @return boolean		true if user have access, otherwise false
      */
-    public function access($what = 'all')
+    public function access()
     {
-        return true;
+        return \Ecodev\Newsletter\Update::access();
     }
 }

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -37,3 +37,12 @@ $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['scheduler']['tasks']['Ecodev\\Newslet
     'title' => 'LLL:EXT:newsletter/Resources/Private/Language/locallang.xlf:task_fetch_bounces_title',
     'description' => 'LLL:EXT:newsletter/Resources/Private/Language/locallang.xlf:task_fetch_bounces_description',
 );
+
+// TCA custom eval
+$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tce']['formevals']['\\Ecodev\\Newsletter\\Tca\\BounceAccountTca'] = 'EXT:' . $_EXTKEY . '/Classes/Tca/BounceAccountTca.php';
+
+// Make a call to update
+if (TYPO3_MODE === 'BE') {
+    $dispatcher = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('TYPO3\\CMS\\Extbase\\SignalSlot\\Dispatcher');
+    $dispatcher->connect('TYPO3\\CMS\\Extensionmanager\\Service\\ExtensionManagementService', 'hasInstalledExtensions', 'Ecodev\\Newsletter\\Update', 'autorun');
+}


### PR DESCRIPTION
The next one: As I explained before I had a mechanism for doing extension updates from another extension I was working on. The reason why I added this was because in my previous pull-request I used the signal-slot to to do the automatic update, and I added my update method to Tools which wasn't wanted.

As I had the code out of the bag I thought this project would benefit from it.
The idea is the extension coder, when creating updates, only has to focus on the actual update and not worry about processing forms. Another feature of this updating mechanism is that it should inform the user when an update fails. And when an update fails any committed data is rolled back leaving the users data intact to a pre-update state. It also keeps track of updates and will notify the user if an update has already been executed and when. Also automatic update tasks are only run once. The update history is written in the localConf for the extension.

The general procedure to adding a update task is :
1) Write your update task method. Your method should: make your data changes in a transaction, return a result object from that transaction/s.
2) Register your update task and method with the Update class, set whether the update task is manual, automatic or both.
3) Forget about it.

The reason why I wrote this is so many times I have had extension updates fail, but do not clean up their mess when they do fail. The idea is to change the mentality by making extension coders more conscientious about updates and what happens when things fail. It is not entirely complete, I have not written file transactions yet. Normally my updates are DB so haven't needed to write it yet.

Eventually I would like to get something like this in extbase.

BTW my french translations are babelfish horrible, feel free to make them french. lol :-)

