### PR TITLE
[TASK] Drop broken "conflicts"

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -28,8 +28,5 @@ $EM_CONF[$_EXTKEY] = array(
             'typo3' => '6.1.0-7.99.99',
             'scheduler' => '6.1.0',
         ),
-        'conflicts' => '',
-        'suggests' => array(
-        ),
     ),
 );


### PR DESCRIPTION
The "conflicts" key in ext_emconf.php must be an array. Simply drop it since it's empty.

Also drop the empty "suggests" key.