### PR TITLE
Add UTF-8 to infoImageAlt()

### DIFF
--- a/Classes/Utility/Validator.php
+++ b/Classes/Utility/Validator.php
@@ -283,7 +283,7 @@ class Validator
         }
 
         $document = new \DOMDocument();
-        @$document->loadHTML($this->content, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+        @$document->loadHTML('<?xml encoding="utf-8" ?>' . $this->content, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
         $imgs = $document->getElementsByTagName('img');
         $count = 0;
         foreach ($imgs as $img) {


### PR DESCRIPTION
By default DOMDocument::loadHTML treats strings as iso, unless declared to utf8