### PR TITLE
Pass the email instance as parameter to substituteMarkersHook()

### DIFF
--- a/Classes/Utility/MarkerSubstitutor.php
+++ b/Classes/Utility/MarkerSubstitutor.php
@@ -44,7 +44,7 @@ class MarkerSubstitutor
         if (is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['newsletter']['substituteMarkersHook'])) {
             foreach ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['newsletter']['substituteMarkersHook'] as $_classRef) {
                 $_procObj = \TYPO3\CMS\Core\Utility\GeneralUtility::getUserObj($_classRef);
-                $result = $_procObj->substituteMarkersHook($result, $name, $markers);
+                $result = $_procObj->substituteMarkersHook($result, $name, $markers, $email);
             }
         }
 


### PR DESCRIPTION
I think it would be handy to pass the email instance to the substitute markers hook, so one can retrieve the email data through the object and get access to the underlying newsletter instance.

I hope I didn't screw up the code style this time. But I only added one word :wink:

Thank you for this extension!