### PR TITLE
[TASK] Require separate TYPO3 packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,12 @@
     "php": ">=5.6.0",
     "ext-mcrypt": "*",
     "ext-dom": "*",
-    "typo3/cms": "^6.2 || ^7.6 || ^8.7 || ^9 || dev-master"
+    "typo3/cms-backend": "^6.2 || ^7.6 || ^8.7 || ^9 || dev-master",
+    "typo3/cms-core": "^6.2 || ^7.6 || ^8.7 || ^9 || dev-master",
+    "typo3/cms-extbase": "^6.2 || ^7.6 || ^8.7 || ^9 || dev-master",
+    "typo3/cms-fluid": "^6.2 || ^7.6 || ^8.7 || ^9 || dev-master",
+    "typo3/cms-lang": "^6.2 || ^7.6 || ^8.7",
+    "typo3/cms-scheduler": "^6.2 || ^7.6 || ^8.7 || ^9 || dev-master"
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^2.1"


### PR DESCRIPTION
This is considered good practice and allows for installing only the really necessary parts of TYPO3. Also starting with TYPO3v9 it is impossible to install "typo3/cms".

There is no "typo3/cms-lang" package anymore in TYPO3v9. This fact alone makes the currently declared full support of TYPO3v9 questionable.