### PR TITLE
Error when sending newsletter from command line - UriBuilder.php / Uncaught TYPO3 Exception rtrim()

### DIFF
--- a/Classes/Utility/UriBuilder.php
+++ b/Classes/Utility/UriBuilder.php
@@ -167,13 +167,13 @@ abstract class UriBuilder
                 $request->setRequestURI(\TYPO3\CMS\Core\Utility\GeneralUtility::getIndpEnv('TYPO3_REQUEST_URL'));
                 $request->setBaseURI(\TYPO3\CMS\Core\Utility\GeneralUtility::getIndpEnv('TYPO3_SITE_URL'));
                 $uriBuilder = $objectManager->get(\TYPO3\CMS\Extbase\Mvc\Web\Routing\UriBuilder::class);
-                # setCreateAbsoluteUri(true) doesn't work in cli mode since \TYPO3\CMS\Core\Utility\GeneralUtility::getIndpEnv('TYPO3_SITE_URL') is not filled correctly without http context
+                // setCreateAbsoluteUri(true) doesn't work in cli mode since \TYPO3\CMS\Core\Utility\GeneralUtility::getIndpEnv('TYPO3_SITE_URL') is not filled correctly without http context
                 $uriBuilder->setRequest($request)
                     ->setUseCacheHash(false)
                     ->setArguments($namespacedArguments)
                     ->setTargetPageType(self::PAGE_TYPE);                
                 
-                # prepend TYPO3_REQUEST_HOST to make uri absolute
+                // prepend TYPO3_REQUEST_HOST to make uri absolute
                 $uri = \TYPO3\CMS\Core\Utility\GeneralUtility::getIndpEnv('TYPO3_REQUEST_HOST') . '/' . $uriBuilder->buildFrontendUri();
             } else {
                 $uri = $uriBuilder->buildFrontendUri();

--- a/Classes/Utility/UriBuilder.php
+++ b/Classes/Utility/UriBuilder.php
@@ -158,6 +158,18 @@ abstract class UriBuilder
                 ->setArguments($namespacedArguments)
                 ->setTargetPageType(self::PAGE_TYPE);
 
+                // check if running cli mode
+                $environment = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('TYPO3\CMS\Extbase\Service\EnvironmentService');
+                if ($environment->isEnvironmentInCliMode()) {
+                    // create a proper context in cli mode before building the uri. buildFrontendUri will otherwise throw an error.
+                    $objectManager = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('TYPO3\CMS\Extbase\Object\ObjectManager');
+                    $request = $objectManager->get(\TYPO3\CMS\Extbase\Mvc\Web\Request::class);
+                    $request->setRequestURI(\TYPO3\CMS\Core\Utility\GeneralUtility::getIndpEnv('TYPO3_REQUEST_URL'));
+                    $request->setBaseURI(\TYPO3\CMS\Core\Utility\GeneralUtility::getIndpEnv('TYPO3_SITE_URL'));
+                    $uriBuilder = $objectManager->get(\TYPO3\CMS\Extbase\Mvc\Web\Routing\UriBuilder::class);
+                    $uriBuilder->setRequest($request);
+                }
+
             $uri = $uriBuilder->buildFrontendUri();
 
             self::$uriCache[$cacheKey] = $uri;


### PR DESCRIPTION
Running send newsletter command with scheduler on command line throws an exception, while running scheduler from backend works fine:

`/usr/bin/php ./html/typo3/sysext/core/bin/typo3 scheduler:run`

> Uncaught TYPO3 Exception rtrim() expects parameter 1 to be string, boolean given
> thrown in file ./typo3/typo3_src-8.7.19/typo3/sysext/frontend/Classes/Typolink/PageLinkBuilder.php
> in line 181

Issue seems to be missing http get context in cli mode. Solution is to create a proper context if not running from frontend.

Environment:
- TYPO3 8.7.19
- PHP 7.0.32-1+ubuntu14.04.1+deb.sury.org+1